### PR TITLE
fixed long standing decompression bug!!!

### DIFF
--- a/src/Codec/Compression/LZ4.hsc
+++ b/src/Codec/Compression/LZ4.hsc
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 -- |
 -- Module      : Codec.Compression.LZ4
 -- Copyright   : (c) Mark Wotton, Austin Seipp 2012
@@ -122,7 +124,7 @@ decompress xs
   where go (l, str) =
           U.unsafeUseAsCString str $ \cstr -> do
             out <- SI.createAndTrim l $ \p -> do
-              r <- fromIntegral <$> c_LZ4_uncompress cstr p (fromIntegral l)
+              r :: Int <- fromIntegral <$> c_LZ4_uncompress cstr p (fromIntegral l)
               --- NOTE: r is the count of bytes c_LZ4_uncompress read from input buffer,
               --- and NOT the count of bytes used in result buffer
               return $! if (r <= 0) then 0 else l

--- a/src/Codec/Compression/LZ4.hsc
+++ b/src/Codec/Compression/LZ4.hsc
@@ -123,7 +123,9 @@ decompress xs
           U.unsafeUseAsCString str $ \cstr -> do
             out <- SI.createAndTrim l $ \p -> do
               r <- fromIntegral <$> c_LZ4_uncompress cstr p (fromIntegral l)
-              return $! if (r <= 0) then 0 else r
+              --- NOTE: r is the count of bytes c_LZ4_uncompress read from input buffer,
+              --- and NOT the count of bytes used in result buffer
+              return $! if (r <= 0) then 0 else l
             return $! if (S.null out) then Nothing else (Just out)
 {-# INLINEABLE decompress #-}
 


### PR DESCRIPTION
Fixed issue https://github.com/mwotton/lz4hs/issues/5#issuecomment-14364357

Also had to add ScopedTypeVariables so that I could annotate the `r` variable with a fixed type and thus suppress having a type Defaulting warning.

An alternative approach to suppressing that warning would be to replace 

``` haskell
              return $! if (r <= 0) then 0 else l
```

with 

``` haskell
              return $! if (r <= 0) then max r 0 else l
```

but that needless complicates reasoning about code that was already somewhat subtle to debug!
(i'm happy to change it to that variant, but I think no one who's going to use this library in the forseeable future isn't using a relatively modern variant of ghc, so  that'd be overkill probably)
